### PR TITLE
Possible fix for embed error in lavender home page

### DIFF
--- a/library.js
+++ b/library.js
@@ -2,12 +2,12 @@
 	"use strict";
 
 	var SoundCloud = {},
-		embed = '<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//soundcloud.com/$1/$2"></iframe>';
+		embed = '<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//soundcloud.com/$1"></iframe>';
 
 
 	SoundCloud.parse = function(postContent, callback) {
 		// modified from http://stackoverflow.com/questions/7168987/
-		postContent = postContent.replace(/<a href="(?:https?:\/\/)?(?:www\.)?(?:soundcloud\.com)\/?(.+)\/?(.+)<\/a>/g, embed);
+		postContent = postContent.replace(/<a href="(?:https?:\/\/)?(?:www\.)?(?:soundcloud\.com)\/?(.+)<\/a>/g, embed);
 		callback(null, postContent);
 	};
 


### PR DESCRIPTION
Removed `/$2` from embed frame and regex so entire URL can be parsed using `$1`
