### PR TITLE
Added ability to embed sets

### DIFF
--- a/library.js
+++ b/library.js
@@ -1,15 +1,22 @@
 (function(module) {
-	"use strict";
+    "use strict";
+    var Soundcloud = {},
+        embed = '<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https://soundcloud.com/$1/$2&amp;show_artwork=true"></iframe>',
+        embeds = '<iframe width="100%" height="410" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https://soundcloud.com/$1/sets/$2&amp;show_artwork=true"></iframe>'
 
-	var SoundCloud = {},
-		embed = '<iframe class="soundclound-embed" width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https://soundcloud.com/$1"></iframe>';
+    Soundcloud.parse = function(postContent, callback) {
+        var	embedtrack = /<a href="(?:https?:\/\/)?(?:www\.)?(?:soundcloud\.com)\/?([\w\-_]+)\/([\w\-_]+)">.+<\/a>/g;
+        var	embedset = /<a href="(?:https?:\/\/)?(?:www\.)?(?:soundcloud\.com)\/?([\w\-_]+)\/sets\/([\w\-_]+)">.+<\/a>/g;
 
+        if (postContent.match(embedtrack)) {
+            postContent = postContent.replace(embedtrack, embed);
+        }
+        if (postContent.match(embedset)) {
+            postContent = postContent.replace(embedset, embeds);
+        }
 
-	SoundCloud.parse = function(postContent, callback) {
-		// modified from http://stackoverflow.com/questions/7168987/
-		postContent = postContent.replace(/<a href="(?:https?:\/\/)?(?:www\.)?(?:soundcloud\.com)\/?(.+)">.+<\/a>/g, embed);
-		callback(null, postContent);
-	};
+        callback(null, postContent);
+    };
 
-	module.exports = SoundCloud;
+    module.exports = Soundcloud;
 }(module));


### PR DESCRIPTION
Current library.js file doesn't display sets correctly due to soundcloud height being fixed at 166. Have split them into two different iFrames, If the URL contains `/sets/` it displays the other iFrame, with the adjusted height to show the set list. If it doesn't. It displays as before. 

Don't forget to publish as I've updated the readme as well.
