### PR TITLE
Update for 0.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "nodebb-plugin-soundcloud",
-  "version": "0.1.0",
+  "version": "0.2.0",
+  "nbbpm": {
+    "compatibility": "^0.6.0"
+  },
   "description": "NodeBB SoundCloud Plugin",
   "main": "library.js",
   "scripts": {
@@ -27,6 +30,6 @@
   },
   "readme": "",
   "readmeFilename": "README.md",
-  "_id": "nodebb-plugin-soundcloud@0.1.0",
-  "_from": "nodebb-plugin-soundcloud@~0.1.0"
+  "_id": "nodebb-plugin-soundcloud@0.2.0",
+  "_from": "nodebb-plugin-soundcloud@~0.2.0"
 }


### PR DESCRIPTION
Update for 0.6.0 support. 

NOTE: Before publishing this update to NPM, please read this topic: https://community.nodebb.org/topic/3117/plugin-developers-read-this-re-v0-6-0-breaking-changes

Namely the part about making sure your plugin still works with 0.5.x.
